### PR TITLE
fix: update SP category logic

### DIFF
--- a/src/trackers/SP.py
+++ b/src/trackers/SP.py
@@ -39,16 +39,11 @@ class SP():
         category_name = meta.get('category', '').upper()
         release_title = meta.get('name', '')
         mal_id = meta.get('mal_id', 0)
-        tv_pack = meta.get('tv_pack', 0)
 
         # Custom SEEDPOOL category logic
-        # Anime
-        if mal_id != 0:
+        # Anime TV go in the Anime category
+        if mal_id != 0 and category_name == 'TV':
             return '6'
-
-        # Boxset
-        if tv_pack != 0:
-            return '13'
 
         # Sports
         if self.contains_sports_patterns(release_title):


### PR DESCRIPTION
Updates SP category logic to match tracker category revisions

- Remove TV Pack category
- Only set TV in the Anime category. Movies go to movies/other category